### PR TITLE
Update PyProject Toml - License

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "comfyui_demucs"
 description = "Using Demucs in comfyUI, make Music Source Separation"
 version = "1.0.0"
-license = "LICENSE"
+license = { file = "LICENSE" }
 dependencies = ["# please make sure you have already a pytorch install that is cuda enabled!", "dora-search>=0.1.12", "diffq>=0.2.1", "einops", "flake8", "hydra-colorlog>=1.1", "hydra-core>=1.1", "julius>=0.2.3", "lameenc>=1.2", "museval", "mypy", "openunmix", "pyyaml", "submitit", "torch>=1.8.1", "torchaudio>=0.8,<2.1", "tqdm", "treetable", "soundfile>=0.10.3;sys_platform==\"win32\""]
 
 [project.urls]


### PR DESCRIPTION
Hey! Robin from [comfy.org](https://comfy.org/) again 😊.

As a heads up, the `license` field is **optional** but in the case that it is filled out, the license file should be referenced either by the file path or by the name of the license.
- `license = { file = "LICENSE" }` ✅
- `license = {text = "MIT License"}` ✅
- `license = "LICENSE"` ❌
- `license = "MIT LICENSE"` ❌

This was brought up in our discord and so we're creating a small PR to update that optional field. For more info check out toml file [standards](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license) or our [docs](https://docs.comfy.org/registry/specifications#license) page!